### PR TITLE
Remove root URL https://localhost:3000 added during migration to Plugin Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.0.1 (2023-08-02)
+
+### Bugfix
+
+- Remove root URL https://localhost:3000 added during migration to Plugin Tools
+
 ## 3.0.0 (2023-07-26)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
     "levitate": "npx @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data,@grafana/runtime,@grafana/ui",
     "lint": "eslint --ignore-path ./.eslintignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "eslint --fix --ignore-path ./.eslintignore --ext .js,.jsx,.ts,.tsx .",
-    "sign": "npx --yes @grafana/sign-plugin@latest --rootUrls http://localhost:3000/",
+    "sign": "npx --yes @grafana/sign-plugin@latest",
     "start": "docker-compose pull && docker-compose up",
     "stop": "docker-compose down",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4 --coverage",
     "upgrade": "npm upgrade --save"
   },
-  "version": "3.0.0"
+  "version": "3.0.1"
 }


### PR DESCRIPTION
Resolves #57.