### PR TITLE
Remove Alerting support in Plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
 - Added XML Server (#75)
 - Updated to Grafana 11.0 and dependencies (#72)
 - Update fields in items getting mixed up (#76)
+- Remove Alerting support in Plugin configuration (#77)
 
 ## 4.0.0 (2024-05-09)
 
 ### Breaking changes
 
-- Requires Grafana 10 and Grafana 11
+- Requires Grafana 10.1 and Grafana 11
 
 ### Features / Enhancements
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
-  "alerting": true,
+  "alerting": false,
   "dependencies": {
     "grafanaDependency": ">=10.1.0",
     "plugins": []


### PR DESCRIPTION
Submission error:

```
Found 1 error(s):

  * Problem: Found alerting in plugin.json but backend=false
    Details: You have marked your plugin with backend=false in plugin.json but declared an alerting=true Please set backend=true in your plugin.json if your plugin has a backend component
```